### PR TITLE
fix: Add correct project reference in IncidentBot to fix builds

### DIFF
--- a/Samples/V1.0Samples/RemoteMediaSamples/IncidentBot.sln
+++ b/Samples/V1.0Samples/RemoteMediaSamples/IncidentBot.sln
@@ -12,7 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IncidentBot", "IncidentBot\IncidentBot.csproj", "{FA70E97D-7018-4B08-A9D0-ABA9967AD7DC}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.Common.Beta", "..\..\Common\Sample.Common.Beta\Sample.Common.Beta.csproj", "{3268E59C-90DC-4D7B-97EA-A1DBB2716DF3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.Common.Beta", "..\..\Common\Sample.Common.Beta\Sample.Common.Beta.csproj", "{DDCA8DFA-7CA3-491A-97DC-3601368E10E6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,10 +24,10 @@ Global
 		{FA70E97D-7018-4B08-A9D0-ABA9967AD7DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FA70E97D-7018-4B08-A9D0-ABA9967AD7DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FA70E97D-7018-4B08-A9D0-ABA9967AD7DC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3268E59C-90DC-4D7B-97EA-A1DBB2716DF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3268E59C-90DC-4D7B-97EA-A1DBB2716DF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3268E59C-90DC-4D7B-97EA-A1DBB2716DF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3268E59C-90DC-4D7B-97EA-A1DBB2716DF3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DDCA8DFA-7CA3-491A-97DC-3601368E10E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DDCA8DFA-7CA3-491A-97DC-3601368E10E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DDCA8DFA-7CA3-491A-97DC-3601368E10E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DDCA8DFA-7CA3-491A-97DC-3601368E10E6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Samples/V1.0Samples/RemoteMediaSamples/IncidentBot/Bot/Bot.cs
+++ b/Samples/V1.0Samples/RemoteMediaSamples/IncidentBot/Bot/Bot.cs
@@ -480,7 +480,7 @@ namespace Sample.IncidentBot.Bot
             var statusData = this.IncidentStatusManager.GetIncident(incidentCallContext.IncidentId);
 
             CallHandler callHandler;
-            ParticipantInfo callee;
+            InvitationParticipantInfo callee;
             switch (incidentCallContext.CallType)
             {
                 case IncidentCallType.BotMeeting:

--- a/Samples/V1.0Samples/RemoteMediaSamples/IncidentBot/IncidentBot.csproj
+++ b/Samples/V1.0Samples/RemoteMediaSamples/IncidentBot/IncidentBot.csproj
@@ -24,9 +24,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Graph.Communications.Calls" Version="1.2.0.1" />
+    <PackageReference Include="Microsoft.Graph.Communications.Calls" Version="1.2.0-beta.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
-    <ProjectReference Include="..\..\..\Common\Sample.Common\Sample.Common.csproj" />
+    <ProjectReference Include="..\..\..\Common\Sample.Common.Beta\Sample.Common.Beta.csproj" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 


### PR DESCRIPTION
Updates the `Sample.Common.Beta` project reference to match the project that has been added to the `IncidentBot` solution. This gets the solution building again, without it this error is thrown during build:

```
Severity	Code	Description	Project	File	Line	Suppression State
Error	NU1105	Unable to find project information for 'C:\Users\alexp\Source\Repos\microsoft-graph-comms-samples\Samples\Common\Sample.Common\Sample.Common.csproj'. If you are using Visual Studio, this may be because the project is unloaded or not part of the current solution so run a restore from the command-line. Otherwise, the project file may be invalid or missing targets required for restore.	IncidentBot	C:\Users\alexp\Source\Repos\microsoft-graph-comms-samples\Samples\V1.0Samples\RemoteMediaSamples\IncidentBot\IncidentBot.csproj	1	

```

Note the `Sample.Common.Beta` project uses beta versions of the Microsoft Graph API (1.2.0-beta.1) which are now outdated. This PR is just around making the smallest change possible to get `IncidentBot` building, so I figure updating the dependencies is out of scope.