### PR TITLE
Added compile-time-configurable features to AudioVideoPlaybackBot

### DIFF
--- a/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/FrontEnd/AVPFrontEnd.csproj
+++ b/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/FrontEnd/AVPFrontEnd.csproj
@@ -18,19 +18,21 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;PLAY_MEDIA_FILE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>latest</LangVersion>
     <ErrorReport>prompt</ErrorReport>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>PLAY_MEDIA_FILE;TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Bot\Bot.cs" />

--- a/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/FrontEnd/Bot/Bot.cs
+++ b/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/FrontEnd/Bot/Bot.cs
@@ -9,6 +9,7 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Data;
+    using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.Graph;
     using Microsoft.Graph.Communications.Calls;
@@ -226,12 +227,21 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
                 new VideoSocketSettings
                 {
                     StreamDirections = StreamDirection.Sendrecv,
+
+#if USE_NV12
+                    ReceiveColorFormat = VideoColorFormat.NV12,
+#else
                     ReceiveColorFormat = VideoColorFormat.H264,
+#endif
 
-                    // We loop back the video in this sample. The MediaPlatform always sends only NV12 frames.
-                    // So include only NV12 video in supportedSendVideoFormats
+#if PLAY_MEDIA_FILE
+                    // We play a pre-recorded video from disk in this sample. The MediaPlatform always sends only H264 frames.
+                    // So include only H264 video in supportedSendVideoFormats
                     SupportedSendVideoFormats = SampleConstants.SupportedSendVideoFormats,
-
+#else
+                    // Otherwise we can support a wide range of formats when manipulating raw video frames.
+                    SupportedSendVideoFormats = BotMediaStream.VideoFormatMap.Values.OfType<VideoFormat>().ToList(),
+#endif
                     MaxConcurrentSendStreams = 1,
                 },
             };
@@ -242,7 +252,11 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
                 videoSocketSettings.Add(new VideoSocketSettings
                 {
                     StreamDirections = StreamDirection.Recvonly,
+#if USE_NV12
+                    ReceiveColorFormat = VideoColorFormat.NV12,
+#else
                     ReceiveColorFormat = VideoColorFormat.H264,
+#endif
                 });
             }
 
@@ -250,12 +264,20 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
             var vbssSocketSettings = new VideoSocketSettings
             {
                 StreamDirections = StreamDirection.Recvonly,
+#if USE_NV12
+                ReceiveColorFormat = VideoColorFormat.NV12,
+#else
                 ReceiveColorFormat = VideoColorFormat.H264,
+#endif
                 MediaType = MediaType.Vbss,
                 SupportedSendVideoFormats = new List<VideoFormat>
                 {
                     // fps 1.875 is required for h264 in vbss scenario.
+#if USE_NV12
+                    VideoFormat.NV12_1920x1080_1_875Fps,
+#else
                     VideoFormat.H264_1920x1080_1_875Fps,
+#endif
                 },
             };
 

--- a/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/FrontEnd/Bot/BotMediaStream.cs
+++ b/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/FrontEnd/Bot/BotMediaStream.cs
@@ -86,7 +86,7 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
 #endif
 
 #if SPOTLIGHT_VIDEO
-        private Stopwatch currentStoplightedDuration = Stopwatch.StartNew();
+        private Stopwatch currentSpotlightedDuration = Stopwatch.StartNew();
         private int currentSpotlightSocket = -1;
 #endif
 
@@ -498,7 +498,7 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
                     if (e.SocketId != this.currentSpotlightSocket)
                     {
                         // And if we haven't finished 5 seconds worth of spotlighting for the current person,
-                        if (this.currentStoplightedDuration.Elapsed.TotalSeconds < 5)
+                        if (this.currentSpotlightedDuration.Elapsed.TotalSeconds < 5)
                         {
                             // Just ignore this incoming video data.
                             return;
@@ -506,7 +506,7 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
                         else
                         {
                             // Otherwise it's been enough time and we can switch to this new person.
-                            this.currentStoplightedDuration.Restart();
+                            this.currentSpotlightedDuration.Restart();
                             this.currentSpotlightSocket = e.SocketId;
                         }
                     }

--- a/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/FrontEnd/Bot/BotMediaStream.cs
+++ b/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/FrontEnd/Bot/BotMediaStream.cs
@@ -12,7 +12,9 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Graph.Communications.Calls.Media;
@@ -26,16 +28,50 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
     /// </summary>
     public class BotMediaStream
     {
+        /// <summary>
+        /// Contains a map from simple color/width/height combinations to VideoFormat objects.
+        /// </summary>
+        public static readonly Dictionary<(VideoColorFormat format, int width, int height), VideoFormat> VideoFormatMap = new Dictionary<(VideoColorFormat format, int width, int height), VideoFormat>()
+        {
+#if USE_NV12
+            { (VideoColorFormat.NV12, 1920, 1080), VideoFormat.NV12_1920x1080_30Fps },
+            { (VideoColorFormat.NV12, 1280, 720), VideoFormat.NV12_1280x720_30Fps },
+            { (VideoColorFormat.NV12, 1080, 1920), VideoFormat.NV12_1080x1920_30Fps },
+            { (VideoColorFormat.NV12, 960, 540), VideoFormat.NV12_960x540_30Fps },
+            { (VideoColorFormat.NV12, 848, 480), VideoFormat.NV12_848x480_30Fps },
+            { (VideoColorFormat.NV12, 720, 1280), VideoFormat.NV12_720x1280_30Fps },
+            { (VideoColorFormat.NV12, 640, 360), VideoFormat.NV12_640x360_30Fps },
+            { (VideoColorFormat.NV12, 540, 960), VideoFormat.NV12_540x960_30Fps },
+            { (VideoColorFormat.NV12, 480, 848), VideoFormat.NV12_480x848_30Fps },
+            { (VideoColorFormat.NV12, 480, 270), VideoFormat.NV12_480x270_15Fps },
+            { (VideoColorFormat.NV12, 424, 240), VideoFormat.NV12_424x240_15Fps },
+            { (VideoColorFormat.NV12, 360, 640), VideoFormat.NV12_360x640_30Fps },
+            { (VideoColorFormat.NV12, 320, 180), VideoFormat.NV12_320x180_15Fps },
+            { (VideoColorFormat.NV12, 270, 480), VideoFormat.NV12_270x480_15Fps },
+            { (VideoColorFormat.NV12, 240, 424), VideoFormat.NV12_240x424_15Fps },
+            { (VideoColorFormat.NV12, 180, 320), VideoFormat.NV12_180x320_30Fps },
+#else
+            { (VideoColorFormat.H264, 1920, 1080), VideoFormat.H264_1920x1080_30Fps },
+            { (VideoColorFormat.H264, 1280, 720), VideoFormat.H264_1280x720_30Fps },
+            { (VideoColorFormat.H264, 960, 540), VideoFormat.H264_960x540_30Fps },
+            { (VideoColorFormat.H264, 640, 360), VideoFormat.H264_640x360_30Fps },
+            { (VideoColorFormat.H264, 424, 240), VideoFormat.H264_424x240_15Fps },
+            { (VideoColorFormat.H264, 320, 180), VideoFormat.H264_320x180_15Fps },
+#endif
+        };
+
         private readonly IAudioSocket audioSocket;
         private readonly IVideoSocket mainVideoSocket;
         private readonly IVideoSocket vbssSocket;
         private readonly List<IVideoSocket> videoSockets;
+        private readonly ILocalMediaSession mediaSession;
+        private readonly IGraphLogger logger;
+
+#if PLAY_MEDIA_FILE
         private readonly TaskCompletionSource<bool> audioSendStatusActive;
         private readonly TaskCompletionSource<bool> videoSendStatusActive;
         private readonly TaskCompletionSource<bool> startVideoPlayerCompleted;
         private readonly object mLock = new object();
-        private readonly ILocalMediaSession mediaSession;
-        private readonly IGraphLogger logger;
         private AudioVideoFramePlayerSettings audioVideoFramePlayerSettings;
         private AudioVideoFramePlayer audioVideoFramePlayer;
         private AudioVideoFramePlayer vbssFramePlayer;
@@ -47,6 +83,13 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
         private List<VideoMediaBuffer> vbssMediaBuffers = new List<VideoMediaBuffer>();
         private List<VideoFormat> videoKnownSupportedFormats;
         private List<VideoFormat> vbssKnownSupportedFormats;
+#endif
+
+#if SPOTLIGHT_VIDEO
+        private Stopwatch currentStoplightedDuration = Stopwatch.StartNew();
+        private int currentSpotlightSocket = -1;
+#endif
+
         private int shutdown;
 
         /// <summary>
@@ -61,10 +104,21 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
 
             this.mediaSession = mediaSession;
             this.logger = logger;
+
+#if SPOTLIGHT_VIDEO && !USE_NV12
+#error Cannot use the SPOTLIGHT_VIDEO option without USE_NV12 because Teams only handles different incoming/outgoing formats when using NV12, not H264.
+#endif
+
+#if PLAY_MEDIA_FILE
+
+#if USE_NV12
+#error Cannot use the PLAY_MEDIA_FILE option with USE_NV12 because we only have .264 files checked into the sample codebase.  We don't have NV12-formatted video files here yet.
+#endif
+
             this.audioSendStatusActive = new TaskCompletionSource<bool>();
             this.videoSendStatusActive = new TaskCompletionSource<bool>();
             this.startVideoPlayerCompleted = new TaskCompletionSource<bool>();
-
+#endif
             this.audioSocket = this.mediaSession.AudioSocket;
             if (this.audioSocket == null)
             {
@@ -79,10 +133,13 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
             {
                 this.mainVideoSocket.VideoSendStatusChanged += this.OnVideoSendStatusChanged;
                 this.mainVideoSocket.VideoKeyFrameNeeded += this.OnVideoKeyFrameNeeded;
-                this.mainVideoSocket.VideoMediaReceived += this.OnVideoMediaReceived;
             }
 
             this.videoSockets = this.mediaSession.VideoSockets?.ToList();
+            foreach (var videoSocket in this.videoSockets)
+            {
+                videoSocket.VideoMediaReceived += this.OnVideoMediaReceived;
+            }
 
             this.vbssSocket = this.mediaSession.VbssSocket;
             if (this.vbssSocket != null)
@@ -90,7 +147,9 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
                 this.vbssSocket.VideoSendStatusChanged += this.OnVbssSocketSendStatusChanged;
             }
 
+#if PLAY_MEDIA_FILE
             var ignoreTask = this.StartAudioVideoFramePlayerAsync().ForgetAndLogExceptionAsync(this.logger, "Failed to start the player");
+#endif
         }
 
         /// <summary>
@@ -175,14 +234,9 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
                 return;
             }
 
+#if PLAY_MEDIA_FILE
             await this.startVideoPlayerCompleted.Task.ConfigureAwait(false);
-
-            // unsubscribe
-            this.audioVideoFramePlayer.LowOnFrames -= this.OnAudioVideoFramePlayerLowOnFrames;
-            if (this.vbssFramePlayer != null)
-            {
-                this.vbssFramePlayer.LowOnFrames -= this.OnVbssPlayerLowOnFrames;
-            }
+#endif
 
             if (this.audioSocket != null)
             {
@@ -194,7 +248,14 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
             {
                 this.mainVideoSocket.VideoKeyFrameNeeded -= this.OnVideoKeyFrameNeeded;
                 this.mainVideoSocket.VideoSendStatusChanged -= this.OnVideoSendStatusChanged;
-                this.mainVideoSocket.VideoMediaReceived -= this.OnVideoMediaReceived;
+            }
+
+            if (this.videoSockets != null)
+            {
+                foreach (var videoSocket in this.videoSockets)
+                {
+                    videoSocket.VideoMediaReceived -= this.OnVideoMediaReceived;
+                }
             }
 
             if (this.vbssSocket != null)
@@ -202,14 +263,17 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
                 this.vbssSocket.VideoSendStatusChanged -= this.OnVbssSocketSendStatusChanged;
             }
 
+#if PLAY_MEDIA_FILE
             // shutting down the players
             if (this.audioVideoFramePlayer != null)
             {
+                this.audioVideoFramePlayer.LowOnFrames -= this.OnAudioVideoFramePlayerLowOnFrames;
                 await this.audioVideoFramePlayer.ShutdownAsync().ConfigureAwait(false);
             }
 
             if (this.vbssFramePlayer != null)
             {
+                this.vbssFramePlayer.LowOnFrames -= this.OnVbssPlayerLowOnFrames;
                 await this.vbssFramePlayer.ShutdownAsync().ConfigureAwait(false);
             }
 
@@ -236,6 +300,10 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
             this.audioMediaBuffers.Clear();
             this.videoMediaBuffers.Clear();
             this.vbssMediaBuffers.Clear();
+#else
+            // Just complying with the style cop because in this case there were no awaits in this method.
+            await Task.CompletedTask.ConfigureAwait(false);
+#endif
         }
 
         /// <summary>
@@ -250,6 +318,7 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
             }
         }
 
+#if PLAY_MEDIA_FILE
         /// <summary>
         /// Event to signal the player is low on frames.
         /// </summary>
@@ -283,9 +352,11 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
         {
             try
             {
+                this.logger.Info("[StartAudioVideoFramePlayerAsync] Waiting for the audio and video send status active tasks to be set as complete.");
+
                 await Task.WhenAll(this.audioSendStatusActive.Task, this.videoSendStatusActive.Task).ConfigureAwait(false);
 
-                this.logger.Info("Send status active for audio and video Creating the audio video player");
+                this.logger.Info("[StartAudioVideoFramePlayerAsync] Send status active for audio and video Creating the audio video player");
                 this.audioVideoFramePlayerSettings =
                     new AudioVideoFramePlayerSettings(new AudioSettings(20), new VideoSettings(), 1000);
                 this.audioVideoFramePlayer = new AudioVideoFramePlayer(
@@ -293,7 +364,7 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
                     (VideoSocket)this.mainVideoSocket,
                     this.audioVideoFramePlayerSettings);
 
-                this.logger.Info("created the audio video player");
+                this.logger.Info("[StartAudioVideoFramePlayerAsync] created the audio video player");
 
                 this.audioVideoFramePlayer.LowOnFrames += this.OnAudioVideoFramePlayerLowOnFrames;
 
@@ -305,13 +376,14 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
             }
             catch (Exception ex)
             {
-                this.logger.Error(ex, "Failed to create the audioVideoFramePlayer with exception");
+                this.logger.Error(ex, "[StartAudioVideoFramePlayerAsync] Failed to create the audioVideoFramePlayer with exception");
             }
             finally
             {
                 this.startVideoPlayerCompleted.TrySetResult(true);
             }
         }
+#endif
 
         /// <summary>
         /// Callback for informational updates from the media plaform about audio status changes.
@@ -323,14 +395,16 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
         {
             this.logger.Info($"[AudioSendStatusChangedEventArgs(MediaSendStatus={e.MediaSendStatus})]");
 
+#if PLAY_MEDIA_FILE
             if (e.MediaSendStatus == MediaSendStatus.Active)
             {
                 this.audioSendStatusActive.TrySetResult(true);
             }
+#endif
         }
 
         /// <summary>
-        /// Save screenshots when we receive audio from the subscribed participant.
+        /// Do something when we receive audio from subscribed participant.
         /// </summary>
         /// <param name="sender">
         /// The sender.
@@ -340,7 +414,6 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
         /// </param>
         private void OnAudioMediaReceived(object sender, AudioMediaReceivedEventArgs e)
         {
-            // leave only logging in here
             this.logger.Info($"[AudioMediaReceivedEventArgs(Data=<{e.Buffer.Data.ToString()}>, Length={e.Buffer.Length}, Timestamp={e.Buffer.Timestamp}, AudioFormat={e.Buffer.AudioFormat}, IsSilence={e.Buffer.IsSilence}, ActiveSpeakers=[{string.Join(", ", e.Buffer.ActiveSpeakers)}])]");
 
             /* TODO: Do something with audio here */
@@ -358,6 +431,7 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
         {
             this.logger.Info($"[VideoSendStatusChangedEventArgs(MediaSendStatus=<{e.MediaSendStatus}>]");
 
+#if PLAY_MEDIA_FILE
             if (e.MediaSendStatus == MediaSendStatus.Active)
             {
                 this.logger.Info($"[VideoSendStatusChangedEventArgs(MediaSendStatus=<{e.MediaSendStatus}>;PreferredVideoSourceFormat=<{string.Join(";", e.PreferredEncodedVideoSourceFormats.ToList())}>]");
@@ -373,7 +447,7 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
                 {
                     if (this.videoKnownSupportedFormats != null && this.videoKnownSupportedFormats.Any() &&
 
-                        // here it means we got a new video fromat so we need to restart the player
+                        // here it means we got a new video format so we need to restart the player
                         this.videoKnownSupportedFormats.Select(x => x.GetId()).Except(previousSupportedFormats.Select(y => y.GetId())).Any())
                     {
                         // we restart the player
@@ -396,10 +470,11 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
                     this.audioVideoFramePlayer?.ClearAsync().ForgetAndLogExceptionAsync(this.logger);
                 }
             }
+#endif
         }
 
         /// <summary>
-        /// Save screenshots when we receive video from the subscribed participant.
+        /// Do something with video when we receive video from a subscribed participant.
         /// </summary>
         /// <param name="sender">
         /// The sender.
@@ -409,12 +484,81 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
         /// </param>
         private void OnVideoMediaReceived(object sender, VideoMediaReceivedEventArgs e)
         {
-            // leave only logging in here
-            this.logger.Info($"[VideoMediaReceivedEventArgs(Data=<{e.Buffer.Data.ToString()}>, Length={e.Buffer.Length}, Timestamp={e.Buffer.Timestamp}, Width={e.Buffer.VideoFormat.Width}, Height={e.Buffer.VideoFormat.Height}, ColorFormat={e.Buffer.VideoFormat.VideoColorFormat}, FrameRate={e.Buffer.VideoFormat.FrameRate})]");
+            this.logger.Info($"[VideoMediaReceivedEventArgs(SocketId={e.SocketId}, Data=<{e.Buffer.Data.ToString()}>, Length={e.Buffer.Length}, Timestamp={e.Buffer.Timestamp}, Width={e.Buffer.VideoFormat.Width}, Height={e.Buffer.VideoFormat.Height}, ColorFormat={e.Buffer.VideoFormat.VideoColorFormat}, FrameRate={e.Buffer.VideoFormat.FrameRate})]");
 
             /* TODO: Do something with video here */
 
+#if SPOTLIGHT_VIDEO
+            // Ignore our own video from the main video socket (so we don't spotlight the bot's own outgoing video).
+            if (this.mainVideoSocket != null && e.SocketId != this.mainVideoSocket.SocketId)
+            {
+                lock (this.mainVideoSocket)
+                {
+                    // If this video is coming from a different (non-spotlighted) person...
+                    if (e.SocketId != this.currentSpotlightSocket)
+                    {
+                        // And if we haven't finished 5 seconds worth of spotlighting for the current person,
+                        if (this.currentStoplightedDuration.Elapsed.TotalSeconds < 5)
+                        {
+                            // Just ignore this incoming video data.
+                            return;
+                        }
+                        else
+                        {
+                            // Otherwise it's been enough time and we can switch to this new person.
+                            this.currentStoplightedDuration.Restart();
+                            this.currentSpotlightSocket = e.SocketId;
+                        }
+                    }
+
+                    if (this.TryCloneVideoBuffer(e.Buffer, out var clonedMediaBuffer))
+                    {
+                        this.logger.Verbose($"[OnVideoMediaReceived] Sending {e.Buffer.Length} byte {e.Buffer.VideoFormat.Width}x{e.Buffer.VideoFormat.Height} {e.Buffer.VideoFormat.VideoColorFormat} video frame to outgoing video socket.");
+
+                        this.mainVideoSocket.Send(clonedMediaBuffer);
+                    }
+                    else
+                    {
+                        this.logger.Error($"[OnVideoMediaReceived] The incoming video format ({e.Buffer.VideoFormat.Width}x{e.Buffer.VideoFormat.Height} {e.Buffer.VideoFormat.VideoColorFormat}) does not have an entry in the VideoFormatMap of valid values.");
+                    }
+                }
+            }
+#endif
+
             e.Buffer.Dispose();
+        }
+
+        /// <summary>
+        /// Tries to clone an incoming video buffer.
+        /// </summary>
+        /// <param name="buffer">The incoming video buffer.</param>
+        /// <param name="clonedBuffer">The cloned buffer.</param>
+        /// <returns>Whether or not we were able to clone the buffer.</returns>
+        private bool TryCloneVideoBuffer(VideoMediaBuffer buffer, out VideoMediaBuffer clonedBuffer)
+        {
+            if (buffer.Length != buffer.VideoFormat.Width * buffer.VideoFormat.Height * 12 / 8)
+            {
+                this.logger.Verbose($"[BotMediaStream] {buffer.Length} != {buffer.VideoFormat.Width} * {buffer.VideoFormat.Height} * 12 / 8 ({buffer.VideoFormat.Width * buffer.VideoFormat.Height * 12 / 8}) or {buffer.OriginalVideoFormat.Width} * {buffer.OriginalVideoFormat.Height} * 12 / 8 ({buffer.OriginalVideoFormat.Width * buffer.OriginalVideoFormat.Height * 12 / 8})");
+            }
+
+            // The incoming buffer.VideoFormat always has 0 for FrameRate and BitRate, but from this point forward we need to pass valid values.
+            var incomingDimensions = (buffer.VideoFormat.VideoColorFormat, buffer.VideoFormat.Width, buffer.VideoFormat.Height);
+            if (VideoFormatMap.TryGetValue(incomingDimensions, out var validFormat))
+            {
+                // Clone the memory data buffer and create a duplicate VideoSendBuffer object with the cloned data
+                var length = buffer.VideoFormat.VideoColorFormat == VideoColorFormat.NV12 ? buffer.VideoFormat.Width * buffer.VideoFormat.Height * 12 / 8 : buffer.Length;
+                var clonedDataPointer = Marshal.AllocHGlobal((int)length);
+                unsafe
+                {
+                    Buffer.MemoryCopy(buffer.Data.ToPointer(), clonedDataPointer.ToPointer(), length, length);
+                }
+
+                clonedBuffer = new VideoSendBuffer(clonedDataPointer, length, validFormat, buffer.Timestamp);
+                return true;
+            }
+
+            clonedBuffer = null;
+            return false;
         }
 
         /// <summary>
@@ -441,8 +585,9 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
         /// </param>
         private void OnVbssSocketSendStatusChanged(object sender, VideoSendStatusChangedEventArgs e)
         {
-            this.logger.Info($"[VbssSendStatusChangedEventArgs(MediaSendStatus=<{e.MediaSendStatus}>]");
+            this.logger.Info($"[VbssSendStatusChangedEventArgs(MediaSendStatus=<{e.MediaSendStatus};PreferredVideoSourceFormat=<{e.PreferredVideoSourceFormat}>]");
 
+#if PLAY_MEDIA_FILE
             if (e.MediaSendStatus == MediaSendStatus.Active)
             {
                 this.logger.Info($"[VbssSendStatusChangedEventArgs(MediaSendStatus=<{e.MediaSendStatus}>;PreferredVideoSourceFormat=<{string.Join(";", e.PreferredEncodedVideoSourceFormats.ToList())}>]");
@@ -476,8 +621,10 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
             {
                 this.vbssFramePlayer?.ClearAsync().ForgetAndLogExceptionAsync(this.logger);
             }
+#endif
         }
 
+#if PLAY_MEDIA_FILE
         /// <summary>
         /// Callback handler for the lowOnFrames event that the vbss frame player will raise when there are no more frames to stream.
         /// The behavior is to enqueue more frames.
@@ -548,5 +695,6 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
                 this.logger.Error(ex, $"Failed to create the vbssFramePlayer with exception {ex}");
             }
         }
+#endif
     }
 }

--- a/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/FrontEnd/Bot/BotMediaStream.cs
+++ b/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/FrontEnd/Bot/BotMediaStream.cs
@@ -72,12 +72,14 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
             }
 
             this.audioSocket.AudioSendStatusChanged += this.OnAudioSendStatusChanged;
+            this.audioSocket.AudioMediaReceived += this.OnAudioMediaReceived;
 
             this.mainVideoSocket = this.mediaSession.VideoSockets?.FirstOrDefault();
             if (this.mainVideoSocket != null)
             {
                 this.mainVideoSocket.VideoSendStatusChanged += this.OnVideoSendStatusChanged;
                 this.mainVideoSocket.VideoKeyFrameNeeded += this.OnVideoKeyFrameNeeded;
+                this.mainVideoSocket.VideoMediaReceived += this.OnVideoMediaReceived;
             }
 
             this.videoSockets = this.mediaSession.VideoSockets?.ToList();
@@ -185,12 +187,14 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
             if (this.audioSocket != null)
             {
                 this.audioSocket.AudioSendStatusChanged -= this.OnAudioSendStatusChanged;
+                this.audioSocket.AudioMediaReceived -= this.OnAudioMediaReceived;
             }
 
             if (this.mainVideoSocket != null)
             {
                 this.mainVideoSocket.VideoKeyFrameNeeded -= this.OnVideoKeyFrameNeeded;
                 this.mainVideoSocket.VideoSendStatusChanged -= this.OnVideoSendStatusChanged;
+                this.mainVideoSocket.VideoMediaReceived -= this.OnVideoMediaReceived;
             }
 
             if (this.vbssSocket != null)
@@ -326,6 +330,25 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
         }
 
         /// <summary>
+        /// Save screenshots when we receive audio from the subscribed participant.
+        /// </summary>
+        /// <param name="sender">
+        /// The sender.
+        /// </param>
+        /// <param name="e">
+        /// The audio media received arguments.
+        /// </param>
+        private void OnAudioMediaReceived(object sender, AudioMediaReceivedEventArgs e)
+        {
+            // leave only logging in here
+            this.logger.Info($"[AudioMediaReceivedEventArgs(Data=<{e.Buffer.Data.ToString()}>, Length={e.Buffer.Length}, Timestamp={e.Buffer.Timestamp}, AudioFormat={e.Buffer.AudioFormat}, IsSilence={e.Buffer.IsSilence}, ActiveSpeakers=[{string.Join(", ", e.Buffer.ActiveSpeakers)}])]");
+
+            /* TODO: Do something with audio here */
+
+            e.Buffer.Dispose();
+        }
+
+        /// <summary>
         /// Callback for informational updates from the media plaform about video status changes.
         /// Once the Status becomes active, then video can be sent.
         /// </summary>
@@ -373,6 +396,25 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
                     this.audioVideoFramePlayer?.ClearAsync().ForgetAndLogExceptionAsync(this.logger);
                 }
             }
+        }
+
+        /// <summary>
+        /// Save screenshots when we receive video from the subscribed participant.
+        /// </summary>
+        /// <param name="sender">
+        /// The sender.
+        /// </param>
+        /// <param name="e">
+        /// The video media received arguments.
+        /// </param>
+        private void OnVideoMediaReceived(object sender, VideoMediaReceivedEventArgs e)
+        {
+            // leave only logging in here
+            this.logger.Info($"[VideoMediaReceivedEventArgs(Data=<{e.Buffer.Data.ToString()}>, Length={e.Buffer.Length}, Timestamp={e.Buffer.Timestamp}, Width={e.Buffer.VideoFormat.Width}, Height={e.Buffer.VideoFormat.Height}, ColorFormat={e.Buffer.VideoFormat.VideoColorFormat}, FrameRate={e.Buffer.VideoFormat.FrameRate})]");
+
+            /* TODO: Do something with video here */
+
+            e.Buffer.Dispose();
         }
 
         /// <summary>

--- a/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/FrontEnd/Bot/CallHandler.cs
+++ b/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/FrontEnd/Bot/CallHandler.cs
@@ -54,9 +54,6 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
             // subscribe to dominant speaker event on the audioSocket
             this.Call.GetLocalMediaSession().AudioSocket.DominantSpeakerChanged += this.OnDominantSpeakerChanged;
 
-            // subscribe to the VideoMediaReceived event on the main video socket
-            this.Call.GetLocalMediaSession().VideoSockets.FirstOrDefault().VideoMediaReceived += this.OnVideoMediaReceived;
-
             // susbscribe to the participants updates, this will inform the bot if a particpant left/joined the conference
             this.Call.Participants.OnUpdated += this.ParticipantsOnUpdated;
 
@@ -91,7 +88,6 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
             base.Dispose(disposing);
 
             this.Call.GetLocalMediaSession().AudioSocket.DominantSpeakerChanged -= this.OnDominantSpeakerChanged;
-            this.Call.GetLocalMediaSession().VideoSockets.FirstOrDefault().VideoMediaReceived -= this.OnVideoMediaReceived;
 
             this.Call.OnUpdated -= this.CallOnUpdated;
             this.Call.Participants.OnUpdated -= this.ParticipantsOnUpdated;
@@ -287,23 +283,6 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
                     this.SubscribeToParticipantVideo(participant, forceSubscribe: true);
                 }
             }
-        }
-
-        /// <summary>
-        /// Save screenshots when we receive video from subscribed participant.
-        /// </summary>
-        /// <param name="sender">
-        /// The sender.
-        /// </param>
-        /// <param name="e">
-        /// The video media received arguments.
-        /// </param>
-        private void OnVideoMediaReceived(object sender, VideoMediaReceivedEventArgs e)
-        {
-            // leave only logging in here
-            this.GraphLogger.Info($"[{this.Call.Id}]: Capturing image: [VideoMediaReceivedEventArgs(Data=<{e.Buffer.Data.ToString()}>, Length={e.Buffer.Length}, Timestamp={e.Buffer.Timestamp}, Width={e.Buffer.VideoFormat.Width}, Height={e.Buffer.VideoFormat.Height}, ColorFormat={e.Buffer.VideoFormat.VideoColorFormat}, FrameRate={e.Buffer.VideoFormat.FrameRate})]");
-
-            e.Buffer.Dispose();
         }
 
         /// <summary>

--- a/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/FrontEnd/SampleConstants.cs
+++ b/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/FrontEnd/SampleConstants.cs
@@ -24,6 +24,7 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd
         /// </summary>
         public const uint NumberOfMultiviewSockets = 3;
 
+#if PLAY_MEDIA_FILE
         /// <summary>
         /// Stores a list of supported video formats.
         /// </summary>
@@ -33,5 +34,6 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd
             VideoFormat.H264_640x360_30Fps,
             VideoFormat.H264_320x180_15Fps,
         };
+#endif
     }
 }

--- a/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/README.md
+++ b/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/README.md
@@ -27,6 +27,16 @@ This section walks you through the process of deploying and testing the sample b
     * [Visual Studio 2017+](https://visualstudio.microsoft.com/downloads/)
     * [PostMan](https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop)
 
+### Toggle between features
+
+* Play a movie in multiple resolutions
+   
+    * This feature is turned on by deafult and has a conditional compilation constant `PLAY_MEDIA_FILE` in the `AVPFrontEnd` project to turn the feature ON or OFF.
+
+*  Loopback of meeting attendees video chosen randomly and show it in the main video's output feed.
+    
+    * Use the compilation constants `USE_NV12` and `SPOTLIGHT_VIDEO` in the `AVPFrontEnd` project to see this feature spotlighting a user's video. This feature basically shows you how to handle an incoming video buffer in the raw `NV12` format. Look the function `OnVideoMediaReceived` in `BotMediaStream.cs` to see how this done.
+
 ### Deploy
 
 #### [Azure] deployment

--- a/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/README.md
+++ b/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/README.md
@@ -31,11 +31,11 @@ This section walks you through the process of deploying and testing the sample b
 
 * Play a movie in multiple resolutions
    
-    * This feature is turned on by deafult and has a conditional compilation constant `PLAY_MEDIA_FILE` in the `AVPFrontEnd` project to turn the feature ON or OFF.
+    * This feature is turned on by default and has a conditional compilation constant `PLAY_MEDIA_FILE` in the `AVPFrontEnd` project to turn the feature ON or OFF.
 
-*  Loopback of meeting attendees video chosen randomly and show it in the main video's output feed.
+*  Loopback/spotlight of a meeting attendee's video (chosen randomly) and show it through the bot's main video output feed.
     
-    * Use the compilation constants `USE_NV12` and `SPOTLIGHT_VIDEO` in the `AVPFrontEnd` project to see this feature spotlighting a user's video. This feature basically shows you how to handle an incoming video buffer in the raw `NV12` format. Look the function `OnVideoMediaReceived` in `BotMediaStream.cs` to see how this done.
+    * This feature is off by default.  Define both of the compilation constants `USE_NV12` and `SPOTLIGHT_VIDEO` in the `AVPFrontEnd` project to see this feature spotlighting a user's video. This feature basically shows you how to handle an incoming video buffer in the raw `NV12` format and send it back out through the bot's video socket. Look at the function `OnVideoMediaReceived` in `BotMediaStream.cs` to see how this done.
 
 ### Deploy
 

--- a/Samples/V1.0Samples/LocalMediaSamples/README.md
+++ b/Samples/V1.0Samples/LocalMediaSamples/README.md
@@ -4,11 +4,11 @@ Local media samples give the developer direct access to the inbound and outbound
 
 ## AudioVideoPlaybackBot
 
-The [AudioVideoPlaybackBot](AudioVideoPlaybackBot/README.md) demostrates several features of local media scenarios:
-- Plays a movie in multiple resolutions as the main video output feed. (This is functionality is turned on by default using the conditional compilation constant PLAY_MEDIA_FILE)
+The [AudioVideoPlaybackBot](AudioVideoPlaybackBot/README.md) demonstrates several features of local media scenarios:
+- Plays a movie in multiple resolutions as the main video output feed. (This functionality is turned on by default using the conditional compilation constant PLAY_MEDIA_FILE)
 - Listens to dominant speaker events and subscribes to inbound video feeds of those participants.
 - Allows switching between screen viewing sharer and viewer, and publishes video through the screen sharing socket.
-- Allows a randomly selected user's video to be spotlighted as the main video output feed (This features can be controlled using a compile time conditional constants SPOTLIGHT_VIDEO and USE_NV12). 
+- Allows a randomly selected user's video to be spotlighted through the main video output feed of the bot (This feature can be controlled using the compile time conditional constants SPOTLIGHT_VIDEO and USE_NV12). 
 
 ## HueBot
 

--- a/Samples/V1.0Samples/LocalMediaSamples/README.md
+++ b/Samples/V1.0Samples/LocalMediaSamples/README.md
@@ -5,9 +5,10 @@ Local media samples give the developer direct access to the inbound and outbound
 ## AudioVideoPlaybackBot
 
 The [AudioVideoPlaybackBot](AudioVideoPlaybackBot/README.md) demostrates several features of local media scenarios:
-- Plays a movie in multiple resolutions as the main video output feed.
+- Plays a movie in multiple resolutions as the main video output feed. (This is functionality is turned on by default using the conditional compilation constant PLAY_MEDIA_FILE)
 - Listens to dominant speaker events and subscribes to inbound video feeds of those participants.
 - Allows switching between screen viewing sharer and viewer, and publishes video through the screen sharing socket.
+- Allows a randomly selected user's video to be spotlighted as the main video output feed (This features can be controlled using a compile time conditional constants SPOTLIGHT_VIDEO and USE_NV12). 
 
 ## HueBot
 


### PR DESCRIPTION
Added compile-time constant flags for the ability to toggle on/off three features:
* USE_NV12: Define this to use NV12 format everywhere instead of H264.
* PLAY_MEDIA_FILE: Define this to play the included demo-reel video file when the bot joins a meeting.  (This was the existing behavior of the sample and we are defining by default to keep the existing behavior).
* SPOTLIGHT_VIDEO: Define this to randomly choose a meeting participant every 5 seconds and forward their video out from the bot's video stream.