### PR TITLE
Add Wait for the Task that plays transfer prompt

### DIFF
--- a/Samples/V1.0Samples/RemoteMediaSamples/IncidentBot/Bot/ResponderCallHandler.cs
+++ b/Samples/V1.0Samples/RemoteMediaSamples/IncidentBot/Bot/ResponderCallHandler.cs
@@ -119,7 +119,7 @@ namespace Sample.IncidentBot.Bot
                     this.GraphLogger.Error(ex, $"Failed to play transfering prompt.");
                     throw;
                 }
-            });
+            }).Wait();
         }
 
         /// <summary>


### PR DESCRIPTION
The transfer prompt played before transferring to the incident meeting is clipped because the application thread does not wait for the task thread.