### PR TITLE
Fix Bot MediaStream initialization

### DIFF
--- a/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/FrontEnd/Bot/CallHandler.cs
+++ b/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/FrontEnd/Bot/CallHandler.cs
@@ -45,7 +45,8 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
         /// Initializes a new instance of the <see cref="CallHandler"/> class.
         /// </summary>
         /// <param name="statefulCall">The stateful call.</param>
-        public CallHandler(ICall statefulCall)
+        /// <param name="botMediaStream">The bot MediaStream object responsible for sending/receiving media.</param>
+        public CallHandler(ICall statefulCall, BotMediaStream botMediaStream)
             : base(TimeSpan.FromMinutes(10), statefulCall?.GraphLogger)
         {
             this.Call = statefulCall;
@@ -66,7 +67,7 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
             }
 
             // attach the botMediaStream
-            this.BotMediaStream = new BotMediaStream(this.Call.GetLocalMediaSession(), this.GraphLogger);
+            this.BotMediaStream = botMediaStream;
         }
 
         /// <summary>
@@ -88,6 +89,7 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
+            this.BotMediaStream?.ShutdownAsync().ForgetAndLogExceptionAsync(this.GraphLogger);
             base.Dispose(disposing);
 
             this.Call.GetLocalMediaSession().AudioSocket.DominantSpeakerChanged -= this.OnDominantSpeakerChanged;
@@ -100,8 +102,6 @@ namespace Sample.AudioVideoPlaybackBot.FrontEnd.Bot
             {
                 participant.OnUpdated -= this.OnParticipantUpdated;
             }
-
-            this.BotMediaStream?.ShutdownAsync().ForgetAndLogExceptionAsync(this.GraphLogger);
         }
 
         /// <summary>

--- a/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/WorkerRole/AVPWorkerRole.csproj
+++ b/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/WorkerRole/AVPWorkerRole.csproj
@@ -41,6 +41,9 @@
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
     <PackageReference Include="Microsoft.WindowsAzure.SDK" Version="2.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.Net.Http">
+      <Version>4.3.4</Version>
+    </PackageReference>
     <Reference Include="MonAgentListener, Version=33.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Configuration" />
   </ItemGroup>

--- a/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/WorkerRole/app.config
+++ b/Samples/V1.0Samples/LocalMediaSamples/AudioVideoPlaybackBot/WorkerRole/app.config
@@ -1,89 +1,97 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <system.diagnostics>
-    <sources>
-      <source name="FrontEnd" switchValue="Verbose">
-        <listeners>
-          <add name="AzureDiagnostics" />
-        </listeners>
-      </source>
-      <source name="Media" switchValue="Verbose">
-        <listeners>
-          <add name="AzureDiagnostics" />
-        </listeners>
-      </source>
-      <source name="AuthToken" switchValue="Verbose">
-        <listeners>
-          <add name="AzureDiagnostics" />
-        </listeners>
-      </source>
-    </sources>
+	<system.diagnostics>
+		<sources>
+			<source name="FrontEnd" switchValue="Verbose">
+				<listeners>
+					<add name="AzureDiagnostics" />
+				</listeners>
+			</source>
+			<source name="Media" switchValue="Verbose">
+				<listeners>
+					<add name="AzureDiagnostics" />
+				</listeners>
+			</source>
+			<source name="AuthToken" switchValue="Verbose">
+				<listeners>
+					<add name="AzureDiagnostics" />
+				</listeners>
+			</source>
+		</sources>
 
-    <!--Add for botframework traces-->
-    <sharedListeners>
-      <add type="Microsoft.WindowsAzure.Diagnostics.DiagnosticMonitorTraceListener, Microsoft.WindowsAzure.Diagnostics, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" name="AzureDiagnostics">
-        <filter type="" />
-      </add>
-    </sharedListeners>
+		<!--Add for botframework traces-->
+		<sharedListeners>
+			<add type="Microsoft.WindowsAzure.Diagnostics.DiagnosticMonitorTraceListener, Microsoft.WindowsAzure.Diagnostics, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" name="AzureDiagnostics">
+				<filter type="" />
+			</add>
+		</sharedListeners>
 
-    <switches>
-      <add name="logLevel" value="4" />
-    </switches>
-    <trace autoflush="false" indentsize="4">
-      <listeners>
-        <add type="Microsoft.WindowsAzure.Diagnostics.DiagnosticMonitorTraceListener, Microsoft.WindowsAzure.Diagnostics, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" name="AzureDiagnostics">
-        </add>
-      </listeners>
-    </trace>
-  </system.diagnostics>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
-  </startup>
+		<switches>
+			<add name="logLevel" value="4" />
+		</switches>
+		<trace autoflush="false" indentsize="4">
+			<listeners>
+				<add type="Microsoft.WindowsAzure.Diagnostics.DiagnosticMonitorTraceListener, Microsoft.WindowsAzure.Diagnostics, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" name="AzureDiagnostics">
+				</add>
+			</listeners>
+		</trace>
+	</system.diagnostics>
+	<startup>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+	</startup>
 
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.20.0.0" newVersion="1.20.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Skype.Bots.Media" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.19.0.25" newVersion="1.19.0.25" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+	<runtime>
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.1.3" newVersion="4.1.1.3" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-1.20.0.0" newVersion="1.20.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Skype.Bots.Media" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-1.19.0.25" newVersion="1.19.0.25" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.6.3.0" newVersion="4.6.3.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
 
-  <appSettings>
-    <!-- update these with your Bot Id, AAD application id and your AAD application secret from your bot registration portal. -->
-    <add key="BotName" value="%BotName%" />
-    <add key="AadAppId" value="%AppId%" />
-    <add key="AadAppSecret" value="%AppSecret%" />
-    <add key="H264_1280x720_30Fps" value="output720p.264" />
-    <add key="H264_640x360_30Fps" value="output360p.264" />
-    <add key="H264_320x180_15Fps" value="output180p.264" />
-    <add key="H264_1920X1080_VBSS_15Fps" value="mle1080p15vbss_2500Kbps.264" />
-    <add key="AudioFileLocation" value="downsampled.wav" />
-    <add key="AudioVideoFileLengthInSec" value="70" />
-    <add key="PlaceCallEndpointUrl" value="https://graph.microsoft.com/v1.0" />
-  </appSettings>
+	<appSettings>
+		<!-- update these with your Bot Id, AAD application id and your AAD application secret from your bot registration portal. -->
+		<add key="BotName" value="%BotName%" />
+		<add key="AadAppId" value="%AppId%" />
+		<add key="AadAppSecret" value="%AppSecret%" />
+		<add key="H264_1280x720_30Fps" value="output720p.264" />
+		<add key="H264_640x360_30Fps" value="output360p.264" />
+		<add key="H264_320x180_15Fps" value="output180p.264" />
+		<add key="H264_1920X1080_VBSS_15Fps" value="mle1080p15vbss_2500Kbps.264" />
+		<add key="AudioFileLocation" value="downsampled.wav" />
+		<add key="AudioVideoFileLengthInSec" value="70" />
+		<add key="PlaceCallEndpointUrl" value="https://graph.microsoft.com/v1.0" />
+	</appSettings>
 </configuration>


### PR DESCRIPTION
The BotMediaStream, wrapping the media sockets, needs to be created first. This will ensure that all the media events are subscribed to before the call gets processed. Avoiding a race condition, where the sends status events on the sockets are raised after the CallsOnUpdated with added notification is raised. Media can start flowing before an Establishing notification is sent to the bot.