### PR TITLE
Update the V1 Delta Roster sample to 9486 SDK version

### DIFF
--- a/Samples/Common/Sample.Common.V1/Authentication/AuthenticationProvider.cs
+++ b/Samples/Common/Sample.Common.V1/Authentication/AuthenticationProvider.cs
@@ -93,7 +93,7 @@ namespace Sample.Common.Authentication
             const string schema = "Bearer";
             const string replaceString = "{tenant}";
             const string oauthV2TokenLink = "https://login.microsoftonline.com/{tenant}";
-            const string resource = "https://graph.microsoft.com/beta";
+            const string resource = "https://graph.microsoft.com/";
 
             // If no tenant was specified, we craft the token link using the common tenant.
             // https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints

--- a/Samples/Common/Sample.Common.V1/Sample.Common.V1.csproj
+++ b/Samples/Common/Sample.Common.V1/Sample.Common.V1.csproj
@@ -11,10 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="Microsoft.Graph.Communications.Calls" Version="1.2.0.9212" TargetFramework="net472"/>
-    <PackageReference Include="Microsoft.Graph.Communications.Client" Version="1.2.0.9212" TargetFramework="net472"/>
-    <PackageReference Include="Microsoft.Graph.Communications.Core" Version="1.2.0.9212" TargetFramework="net472"/>
-    <PackageReference Include="Microsoft.Graph.Communications.Common" Version="1.2.0.9212" TargetFramework="net472"/>
+    <PackageReference Include="Microsoft.Graph.Communications.Calls" Version="1.2.0.9486" TargetFramework="net472"/>
+    <PackageReference Include="Microsoft.Graph.Communications.Client" Version="1.2.0.9486" TargetFramework="net472"/>
+    <PackageReference Include="Microsoft.Graph.Communications.Core" Version="1.2.0.9486" TargetFramework="net472"/>
+    <PackageReference Include="Microsoft.Graph.Communications.Common" Version="1.2.0.9486" TargetFramework="net472"/>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2.0" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.2.0.0" />   

--- a/Samples/V1.0DeltaRosterSample/LocalMediaSamples/PolicyRecordingBot/FrontEnd/CRFrontEnd.csproj
+++ b/Samples/V1.0DeltaRosterSample/LocalMediaSamples/PolicyRecordingBot/FrontEnd/CRFrontEnd.csproj
@@ -58,7 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.7" />
-    <PackageReference Include="Microsoft.Graph.Communications.Calls.Media" Version="1.2.0.9212" TargetFramework="net472"/>
+    <PackageReference Include="Microsoft.Graph.Communications.Calls.Media" Version="1.2.0.9486" TargetFramework="net472"/>
     <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.2" />
     <PackageReference Include="Microsoft.Skype.Bots.Media" Version="1.26.0.94-alpha" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2.0" />

--- a/Samples/V1.0DeltaRosterSample/LocalMediaSamples/PolicyRecordingBot/WorkerRole/app.config
+++ b/Samples/V1.0DeltaRosterSample/LocalMediaSamples/PolicyRecordingBot/WorkerRole/app.config
@@ -56,7 +56,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.5.0" newVersion="2.0.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -93,6 +93,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.1" newVersion="7.0.0.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
Summary: 
Changes to upgrade the V1 Delta Roster Policy Recording Sample to use the latest SDK 

Description of Changes:
1. V1 Common to point to graph V1 url 
2. Upgrade to 1.2.0.9486 version of Comms SDK 
3. Upgrade to Graph Core binding