### PR TITLE
Upgrade bot to latest beta version and showcase the use of IsDeltaRosterEnabled callOption

### DIFF
--- a/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot/FrontEnd/Http/Controllers/PlatformCallController.cs
+++ b/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot/FrontEnd/Http/Controllers/PlatformCallController.cs
@@ -167,6 +167,9 @@ namespace Sample.PolicyRecordingBot.FrontEnd.Http
             // The request is valid. Let's evaluate any policies on the
             // incoming call before sending it off to the SDK for processing.
             var call = notifications?.Value?.FirstOrDefault()?.GetResourceData() as Call;
+
+            // Set the call options to enable delta roster notifications.
+            call.CallOptions = new IncomingCallOptions { IsDeltaRosterEnabled = true };
             var response = await EvaluateAndHandleIncomingCallPoliciesAsync(call).ConfigureAwait(false);
             if (response != null)
             {

--- a/Samples/Common/Sample.Common.Beta/Sample.Common.Beta.csproj
+++ b/Samples/Common/Sample.Common.Beta/Sample.Common.Beta.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
+  <PropertyGroup>	  
     <TargetFrameworks>net472</TargetFrameworks>
     <RootNamespace>Sample.Common.Beta</RootNamespace>
     <AssemblyName>Sample.Common.Beta</AssemblyName>
@@ -11,17 +11,15 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
-    <PackageReference Include="Microsoft.Graph.Communications.Calls" Version="1.2.0-beta.9995" TargetFramework="net472" />
-    <PackageReference Include="Microsoft.Graph.Communications.Client" Version="1.2.0-beta.9995" TargetFramework="net472" />
-    <PackageReference Include="Microsoft.Graph.Communications.Core" Version="1.2.0-beta.9995" TargetFramework="net472" />
-    <PackageReference Include="Microsoft.Graph.Communications.Common" Version="1.2.0-beta.9995" TargetFramework="net472" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Graph.Communications.Calls" Version="1.2.0-beta.12553" TargetFramework="net472" />
+    <PackageReference Include="Microsoft.Graph.Communications.Client" Version="1.2.0-beta.12553" TargetFramework="net472" />
+    <PackageReference Include="Microsoft.Graph.Communications.Core" Version="1.2.0-beta.12553" TargetFramework="net472" />
+    <PackageReference Include="Microsoft.Graph.Communications.Common" Version="1.2.0-beta.12553" TargetFramework="net472" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />   
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Abstractions" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">


### PR DESCRIPTION
Upgraded Microsoft.Graph package to the latest beta version - 12553
Removed package reference for Microsoft.IdentityModel as this dependency is part of the new Microsoft.Graph beta version
set incoming callOption `IsDeltaRosterEnabled` to true