### PR TITLE
Update the Beta Calling Sample to use latest Beta

### DIFF
--- a/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot.sln
+++ b/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot.sln
@@ -10,7 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\..\nuget.config = ..\..\nuget.config
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CRFrontEnd", "PolicyRecordingBot\FrontEnd\CRFrontEnd.csproj", "{739D09C4-47E8-42B7-9B89-94DCB890AC0F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CRFrontEnd", "PolicyRecordingBot\FrontEnd\CRFrontEnd.csproj", "{DD039F57-C237-4CAD-9B35-686FC5F5A026}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CRWorkerRole", "PolicyRecordingBot\WorkerRole\CRWorkerRole.csproj", "{EAF11F22-C267-4C02-820D-12B622FEBFC1}"
 EndProject
@@ -24,10 +24,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{739D09C4-47E8-42B7-9B89-94DCB890AC0F}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{739D09C4-47E8-42B7-9B89-94DCB890AC0F}.Debug|Any CPU.Build.0 = Debug|x64
-		{739D09C4-47E8-42B7-9B89-94DCB890AC0F}.Release|Any CPU.ActiveCfg = Release|x64
-		{739D09C4-47E8-42B7-9B89-94DCB890AC0F}.Release|Any CPU.Build.0 = Release|x64
+		{DD039F57-C237-4CAD-9B35-686FC5F5A026}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{DD039F57-C237-4CAD-9B35-686FC5F5A026}.Debug|Any CPU.Build.0 = Debug|x64
+		{DD039F57-C237-4CAD-9B35-686FC5F5A026}.Release|Any CPU.ActiveCfg = Release|x64
+		{DD039F57-C237-4CAD-9B35-686FC5F5A026}.Release|Any CPU.Build.0 = Release|x64
 		{EAF11F22-C267-4C02-820D-12B622FEBFC1}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{EAF11F22-C267-4C02-820D-12B622FEBFC1}.Debug|Any CPU.Build.0 = Debug|x64
 		{EAF11F22-C267-4C02-820D-12B622FEBFC1}.Release|Any CPU.ActiveCfg = Release|x64

--- a/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot/FrontEnd/CRFrontEnd.csproj
+++ b/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot/FrontEnd/CRFrontEnd.csproj
@@ -65,7 +65,7 @@
     <PackageReference Include="System.Text.Encodings.Web">
       <Version>8.0.0</Version>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <Reference Include="System.Data.Entity" />
   </ItemGroup>
   <ItemGroup>

--- a/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot/FrontEnd/Http/Controllers/PlatformCallController.cs
+++ b/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot/FrontEnd/Http/Controllers/PlatformCallController.cs
@@ -168,8 +168,8 @@ namespace Sample.PolicyRecordingBot.FrontEnd.Http
             // incoming call before sending it off to the SDK for processing.
             var call = notifications?.Value?.FirstOrDefault()?.GetResourceData() as Call;
 
-            // Set the call options to enable delta roster notifications.
-            call.CallOptions = new IncomingCallOptions { IsDeltaRosterEnabled = true };
+            // Set the call options to enable delta roster notifications and interactive partial roster.
+            call.CallOptions = new IncomingCallOptions { IsDeltaRosterEnabled = true, IsInteractiveRosterEnabled = true };
             var response = await EvaluateAndHandleIncomingCallPoliciesAsync(call).ConfigureAwait(false);
             if (response != null)
             {

--- a/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot/WorkerRole/CRWorkerRole.csproj
+++ b/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot/WorkerRole/CRWorkerRole.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="System.Text.Encodings.Web">
       <Version>8.0.0</Version>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
     </PackageReference>

--- a/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot/WorkerRole/app.config
+++ b/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot/WorkerRole/app.config
@@ -56,7 +56,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.5.0" newVersion="2.0.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -64,7 +64,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Skype.Bots.Media" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.20.0.348" newVersion="1.20.0.348" />
+        <bindingRedirect oldVersion="0.0.0.0-1.27.0.2" newVersion="1.27.0.2" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="adb9793829ddae60" culture="neutral" />
@@ -80,11 +80,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.3.0" newVersion="7.0.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.2.0" newVersion="8.0.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
@@ -92,7 +92,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.3.3.0" newVersion="1.3.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot/WorkerRole/app.config
+++ b/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot/WorkerRole/app.config
@@ -56,7 +56,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.2.4.0" newVersion="3.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -80,11 +80,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.2" newVersion="8.0.0.2" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.2.0" newVersion="8.0.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.6.1.0" newVersion="8.6.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
@@ -92,7 +92,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.17.1.0" newVersion="1.17.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -104,7 +104,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot/WorkerRole/app.config
+++ b/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot/WorkerRole/app.config
@@ -106,6 +106,10 @@
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Graph.Communications.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.14141" newVersion="1.2.0.14141" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 

--- a/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot/WorkerRole/app.config
+++ b/Samples/BetaSamples/LocalMediaSamples/PolicyRecordingBot/WorkerRole/app.config
@@ -110,6 +110,18 @@
         <assemblyIdentity name="Microsoft.Graph.Communications.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.2.0.14141" newVersion="1.2.0.14141" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Graph.Communications.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.14141" newVersion="1.2.0.14141" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Graph.Communications.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.14141" newVersion="1.2.0.14141" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Graph.Communications.Calls" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.14141" newVersion="1.2.0.14141" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 

--- a/Samples/Common/Sample.Common.Beta/Sample.Common.Beta.csproj
+++ b/Samples/Common/Sample.Common.Beta/Sample.Common.Beta.csproj
@@ -11,15 +11,15 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
-    <PackageReference Include="Microsoft.Graph.Communications.Calls" Version="1.2.0-beta.12553" TargetFramework="net472" />
-    <PackageReference Include="Microsoft.Graph.Communications.Client" Version="1.2.0-beta.12553" TargetFramework="net472" />
-    <PackageReference Include="Microsoft.Graph.Communications.Core" Version="1.2.0-beta.12553" TargetFramework="net472" />
-    <PackageReference Include="Microsoft.Graph.Communications.Common" Version="1.2.0-beta.12553" TargetFramework="net472" />
+    <PackageReference Include="Microsoft.Graph.Communications.Calls" Version="1.2.0-beta.14141" TargetFramework="net472" />
+    <PackageReference Include="Microsoft.Graph.Communications.Client" Version="1.2.0-beta.14141" TargetFramework="net472" />
+    <PackageReference Include="Microsoft.Graph.Communications.Core" Version="1.2.0-beta.14141" TargetFramework="net472" />
+    <PackageReference Include="Microsoft.Graph.Communications.Common" Version="1.2.0-beta.14141" TargetFramework="net472" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />   
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">


### PR DESCRIPTION
Summary of changes: 
1. Update known vulnerable System.text.json package version to stable version
2. Update Graph calling beta nuget in Commons Beta to refer to 1.2.0-beta.14141
3. Add sample to set the InteractivePartialRoster call options flag in CR Sample