### PR TITLE
Add support for short Teams meeting URLs in ParseJoinURL

### DIFF
--- a/Samples/Common/Sample.Common.Beta/Meetings/JoinInfo.cs
+++ b/Samples/Common/Sample.Common.Beta/Meetings/JoinInfo.cs
@@ -28,37 +28,52 @@ namespace Sample.Common.Meetings
         {
             var decodedURL = WebUtility.UrlDecode(joinURL);
 
-            //// URL being needs to be in this format.
+            //// Long URL format:
             //// https://teams.microsoft.com/l/meetup-join/19:cd9ce3da56624fe69c9d7cd026f9126d@thread.skype/1509579179399?context={"Tid":"72f988bf-86f1-41af-91ab-2d7cd011db47","Oid":"550fae72-d251-43ec-868c-373732c2704f","MessageId":"1536978844957"}
 
             var regex = new Regex("https://teams\\.microsoft\\.com.*/(?<thread>[^/]+)/(?<message>[^/]+)\\?context=(?<context>{.*})");
             var match = regex.Match(decodedURL);
-            if (!match.Success)
+            if (match.Success)
             {
-                throw new ArgumentException($"Join URL cannot be parsed: {joinURL}.", nameof(joinURL));
-            }
-
-            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(match.Groups["context"].Value)))
-            {
-                var ctxt = (Context)new DataContractJsonSerializer(typeof(Context)).ReadObject(stream);
-                var chatInfo = new ChatInfo
+                using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(match.Groups["context"].Value)))
                 {
-                    ThreadId = match.Groups["thread"].Value,
-                    MessageId = match.Groups["message"].Value,
-                    ReplyChainMessageId = ctxt.MessageId,
-                };
-
-                var meetingInfo = new OrganizerMeetingInfo
-                {
-                    Organizer = new IdentitySet
+                    var ctxt = (Context)new DataContractJsonSerializer(typeof(Context)).ReadObject(stream);
+                    var chatInfo = new ChatInfo
                     {
-                        User = new Identity { Id = ctxt.Oid },
-                    },
+                        ThreadId = match.Groups["thread"].Value,
+                        MessageId = match.Groups["message"].Value,
+                        ReplyChainMessageId = ctxt.MessageId,
+                    };
+
+                    var meetingInfo = new OrganizerMeetingInfo
+                    {
+                        Organizer = new IdentitySet
+                        {
+                            User = new Identity { Id = ctxt.Oid },
+                        },
+                    };
+
+                    // meetingInfo.Organizer.User.SetTenantId(ctxt.Tid);
+                    return (chatInfo, meetingInfo);
+                }
+            }
+
+            //// Short URL format:
+            //// https://teams.microsoft.com/meet/2414128301281?p=NzhDLMLT8b07DrkwkE
+            var shortUrlRegex = new Regex("https://teams\\.microsoft\\.com/meet/(?<meetingId>[^?]+)\\?p=(?<passcode>.+)");
+            var shortUrlMatch = shortUrlRegex.Match(decodedURL);
+            if (shortUrlMatch.Success)
+            {
+                var meetingInfo = new JoinMeetingIdMeetingInfo
+                {
+                    JoinMeetingId = shortUrlMatch.Groups["meetingId"].Value,
+                    Passcode = shortUrlMatch.Groups["passcode"].Value,
                 };
 
-                // meetingInfo.Organizer.User.SetTenantId(ctxt.Tid);
-                return (chatInfo, meetingInfo);
+                return (new ChatInfo(), meetingInfo);
             }
+
+            throw new ArgumentException($"Join URL cannot be parsed: {joinURL}.", nameof(joinURL));
         }
 
         /// <summary>

--- a/Samples/Common/Sample.Common.V1/Meetings/JoinInfo.cs
+++ b/Samples/Common/Sample.Common.V1/Meetings/JoinInfo.cs
@@ -28,37 +28,52 @@ namespace Sample.Common.Meetings
         {
             var decodedURL = WebUtility.UrlDecode(joinURL);
 
-            //// URL being needs to be in this format.
+            //// Long URL format:
             //// https://teams.microsoft.com/l/meetup-join/19:cd9ce3da56624fe69c9d7cd026f9126d@thread.skype/1509579179399?context={"Tid":"72f988bf-86f1-41af-91ab-2d7cd011db47","Oid":"550fae72-d251-43ec-868c-373732c2704f","MessageId":"1536978844957"}
 
             var regex = new Regex("https://teams\\.microsoft\\.com.*/(?<thread>[^/]+)/(?<message>[^/]+)\\?context=(?<context>{.*})");
             var match = regex.Match(decodedURL);
-            if (!match.Success)
+            if (match.Success)
             {
-                throw new ArgumentException($"Join URL cannot be parsed: {joinURL}.", nameof(joinURL));
-            }
-
-            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(match.Groups["context"].Value)))
-            {
-                var ctxt = (Context)new DataContractJsonSerializer(typeof(Context)).ReadObject(stream);
-                var chatInfo = new ChatInfo
+                using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(match.Groups["context"].Value)))
                 {
-                    ThreadId = match.Groups["thread"].Value,
-                    MessageId = match.Groups["message"].Value,
-                    ReplyChainMessageId = ctxt.MessageId,
-                };
-
-                var meetingInfo = new OrganizerMeetingInfo
-                {
-                    Organizer = new IdentitySet
+                    var ctxt = (Context)new DataContractJsonSerializer(typeof(Context)).ReadObject(stream);
+                    var chatInfo = new ChatInfo
                     {
-                        User = new Identity { Id = ctxt.Oid },
-                    },
+                        ThreadId = match.Groups["thread"].Value,
+                        MessageId = match.Groups["message"].Value,
+                        ReplyChainMessageId = ctxt.MessageId,
+                    };
+
+                    var meetingInfo = new OrganizerMeetingInfo
+                    {
+                        Organizer = new IdentitySet
+                        {
+                            User = new Identity { Id = ctxt.Oid },
+                        },
+                    };
+
+                    // meetingInfo.Organizer.User.SetTenantId(ctxt.Tid);
+                    return (chatInfo, meetingInfo);
+                }
+            }
+
+            //// Short URL format:
+            //// https://teams.microsoft.com/meet/2414128301281?p=NzhDLMLT8b07DrkwkE
+            var shortUrlRegex = new Regex("https://teams\\.microsoft\\.com/meet/(?<meetingId>[^?]+)\\?p=(?<passcode>.+)");
+            var shortUrlMatch = shortUrlRegex.Match(decodedURL);
+            if (shortUrlMatch.Success)
+            {
+                var meetingInfo = new JoinMeetingIdMeetingInfo
+                {
+                    JoinMeetingId = shortUrlMatch.Groups["meetingId"].Value,
+                    Passcode = shortUrlMatch.Groups["passcode"].Value,
                 };
 
-                // meetingInfo.Organizer.User.SetTenantId(ctxt.Tid);
-                return (chatInfo, meetingInfo);
+                return (new ChatInfo(), meetingInfo);
             }
+
+            throw new ArgumentException($"Join URL cannot be parsed: {joinURL}.", nameof(joinURL));
         }
 
         /// <summary>

--- a/Samples/Common/Sample.Common/Meetings/JoinInfo.cs
+++ b/Samples/Common/Sample.Common/Meetings/JoinInfo.cs
@@ -28,37 +28,52 @@ namespace Sample.Common.Meetings
         {
             var decodedURL = WebUtility.UrlDecode(joinURL);
 
-            //// URL being needs to be in this format.
+            //// Long URL format:
             //// https://teams.microsoft.com/l/meetup-join/19:cd9ce3da56624fe69c9d7cd026f9126d@thread.skype/1509579179399?context={"Tid":"72f988bf-86f1-41af-91ab-2d7cd011db47","Oid":"550fae72-d251-43ec-868c-373732c2704f","MessageId":"1536978844957"}
 
             var regex = new Regex("https://teams\\.microsoft\\.com.*/(?<thread>[^/]+)/(?<message>[^/]+)\\?context=(?<context>{.*})");
             var match = regex.Match(decodedURL);
-            if (!match.Success)
+            if (match.Success)
             {
-                throw new ArgumentException($"Join URL cannot be parsed: {joinURL}.", nameof(joinURL));
-            }
-
-            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(match.Groups["context"].Value)))
-            {
-                var ctxt = (Context)new DataContractJsonSerializer(typeof(Context)).ReadObject(stream);
-                var chatInfo = new ChatInfo
+                using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(match.Groups["context"].Value)))
                 {
-                    ThreadId = match.Groups["thread"].Value,
-                    MessageId = match.Groups["message"].Value,
-                    ReplyChainMessageId = ctxt.MessageId,
-                };
-
-                var meetingInfo = new OrganizerMeetingInfo
-                {
-                    Organizer = new IdentitySet
+                    var ctxt = (Context)new DataContractJsonSerializer(typeof(Context)).ReadObject(stream);
+                    var chatInfo = new ChatInfo
                     {
-                        User = new Identity { Id = ctxt.Oid },
-                    },
-                };
-                meetingInfo.Organizer.User.SetTenantId(ctxt.Tid);
+                        ThreadId = match.Groups["thread"].Value,
+                        MessageId = match.Groups["message"].Value,
+                        ReplyChainMessageId = ctxt.MessageId,
+                    };
 
-                return (chatInfo, meetingInfo);
+                    var meetingInfo = new OrganizerMeetingInfo
+                    {
+                        Organizer = new IdentitySet
+                        {
+                            User = new Identity { Id = ctxt.Oid },
+                        },
+                    };
+                    meetingInfo.Organizer.User.SetTenantId(ctxt.Tid);
+
+                    return (chatInfo, meetingInfo);
+                }
             }
+
+            //// Short URL format:
+            //// https://teams.microsoft.com/meet/2414128301281?p=NzhDLMLT8b07DrkwkE
+            var shortUrlRegex = new Regex("https://teams\\.microsoft\\.com/meet/(?<meetingId>[^?]+)\\?p=(?<passcode>.+)");
+            var shortUrlMatch = shortUrlRegex.Match(decodedURL);
+            if (shortUrlMatch.Success)
+            {
+                var meetingInfo = new JoinMeetingIdMeetingInfo
+                {
+                    JoinMeetingId = shortUrlMatch.Groups["meetingId"].Value,
+                    Passcode = shortUrlMatch.Groups["passcode"].Value,
+                };
+
+                return (new ChatInfo(), meetingInfo);
+            }
+
+            throw new ArgumentException($"Join URL cannot be parsed: {joinURL}.", nameof(joinURL));
         }
 
         /// <summary>

--- a/Samples/PublicSamples/EchoBot/src/EchoBot/Bot/BotService.cs
+++ b/Samples/PublicSamples/EchoBot/src/EchoBot/Bot/BotService.cs
@@ -196,7 +196,15 @@ namespace EchoBot.Bot
 
             var tenantId =
                 joinCallBody.TenantId ??
-                (meetingInfo as OrganizerMeetingInfo)?.Organizer.GetPrimaryIdentity()?.GetTenantId();
+                (meetingInfo as OrganizerMeetingInfo)?.Organizer?.GetPrimaryIdentity()?.GetTenantId();
+
+            if (string.IsNullOrWhiteSpace(tenantId))
+            {
+                throw new HttpRequestException(
+                    "TenantId could not be resolved from the join URL or request body.",
+                    null,
+                    HttpStatusCode.BadRequest);
+            }
             var mediaSession = this.CreateLocalMediaSession();
 
             var joinParams = new JoinMeetingParameters(chatInfo, meetingInfo, mediaSession)

--- a/Samples/PublicSamples/EchoBot/src/EchoBot/Bot/BotService.cs
+++ b/Samples/PublicSamples/EchoBot/src/EchoBot/Bot/BotService.cs
@@ -194,7 +194,9 @@ namespace EchoBot.Bot
 
             var (chatInfo, meetingInfo) = JoinInfo.ParseJoinURL(joinCallBody.JoinUrl);
 
-            var tenantId = (meetingInfo as OrganizerMeetingInfo).Organizer.GetPrimaryIdentity().GetTenantId();
+            var tenantId =
+                joinCallBody.TenantId ??
+                (meetingInfo as OrganizerMeetingInfo)?.Organizer.GetPrimaryIdentity()?.GetTenantId();
             var mediaSession = this.CreateLocalMediaSession();
 
             var joinParams = new JoinMeetingParameters(chatInfo, meetingInfo, mediaSession)

--- a/Samples/PublicSamples/EchoBot/src/EchoBot/Models/JoinCallBody.cs
+++ b/Samples/PublicSamples/EchoBot/src/EchoBot/Models/JoinCallBody.cs
@@ -25,6 +25,14 @@ namespace EchoBot.Models
         public string JoinUrl { get; set; }
 
         /// <summary>
+        /// Gets or sets the tenant id.
+        /// Required when using short meeting URLs (e.g. https://teams.microsoft.com/meet/...).
+        /// The tenant id cannot be inferred from short URLs and must be provided separately.
+        /// </summary>
+        /// <value>The tenant id.</value>
+        public string? TenantId { get; set; }
+
+        /// <summary>
         /// Gets or sets the display name.
         /// Teams client does not allow changing of ones own display name.
         /// If display name is specified, we join as anonymous (guest) user

--- a/Samples/PublicSamples/EchoBot/src/EchoBot/Models/JoinInfo.cs
+++ b/Samples/PublicSamples/EchoBot/src/EchoBot/Models/JoinInfo.cs
@@ -43,40 +43,55 @@ namespace EchoBot.Models
 
             var decodedURL = WebUtility.UrlDecode(joinURL);
 
+            //// Long URL format:
             var regex = new Regex("https://teams\\.microsoft\\.com.*/(?<thread>[^/]+)/(?<message>[^/]+)\\?context=(?<context>{.*})");
             var match = regex.Match(decodedURL);
-            if (!match.Success)
+            if (match.Success)
             {
-                throw new ArgumentException($"Join URL cannot be parsed: {joinURL}", nameof(joinURL));
-            }
-
-            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(match.Groups["context"].Value)))
-            {
-                var ctxt = (Meeting)new DataContractJsonSerializer(typeof(Meeting)).ReadObject(stream);
-
-                if (string.IsNullOrEmpty(ctxt.Tid))
+                using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(match.Groups["context"].Value)))
                 {
-                    throw new ArgumentException("Join URL is invalid: missing Tid", nameof(joinURL));
-                }
+                    var ctxt = (Meeting)new DataContractJsonSerializer(typeof(Meeting)).ReadObject(stream);
 
-                var chatInfo = new ChatInfo
-                {
-                    ThreadId = match.Groups["thread"].Value,
-                    MessageId = match.Groups["message"].Value,
-                    ReplyChainMessageId = ctxt.MessageId,
-                };
-
-                var meetingInfo = new OrganizerMeetingInfo
-                {
-                    Organizer = new IdentitySet
+                    if (string.IsNullOrEmpty(ctxt.Tid))
                     {
-                        User = new Identity { Id = ctxt.Oid },
-                    },
-                };
-                meetingInfo.Organizer.User.SetTenantId(ctxt.Tid);
+                        throw new ArgumentException("Join URL is invalid: missing Tid", nameof(joinURL));
+                    }
 
-                return (chatInfo, meetingInfo);
+                    var chatInfo = new ChatInfo
+                    {
+                        ThreadId = match.Groups["thread"].Value,
+                        MessageId = match.Groups["message"].Value,
+                        ReplyChainMessageId = ctxt.MessageId,
+                    };
+
+                    var meetingInfo = new OrganizerMeetingInfo
+                    {
+                        Organizer = new IdentitySet
+                        {
+                            User = new Identity { Id = ctxt.Oid },
+                        },
+                    };
+                    meetingInfo.Organizer.User.SetTenantId(ctxt.Tid);
+
+                    return (chatInfo, meetingInfo);
+                }
             }
+
+            //// Short URL format: https://teams.microsoft.com/meet/<meetingId>?p=<passcode>
+            var shortUrlRegex = new Regex("https://teams\\.microsoft\\.com/meet/(?<meetingId>[^?]+)\\?p=(?<passcode>.+)");
+            var shortUrlMatch = shortUrlRegex.Match(decodedURL);
+            if (shortUrlMatch.Success)
+            {
+                var meetingInfo = new JoinMeetingIdMeetingInfo
+                {
+                    JoinMeetingId = shortUrlMatch.Groups["meetingId"].Value,
+                    Passcode = shortUrlMatch.Groups["passcode"].Value,
+                };
+
+                return (new ChatInfo(), meetingInfo);
+            }
+
+            throw new ArgumentException($"Join URL cannot be parsed: {joinURL}", nameof(joinURL));
         }
     }
 }

--- a/Samples/PublicSamples/PsiBot/PsiBot/PsiBot.Model/Models/JoinCallBody.cs
+++ b/Samples/PublicSamples/PsiBot/PsiBot/PsiBot.Model/Models/JoinCallBody.cs
@@ -17,6 +17,14 @@ namespace PsiBot.Model.Models
         public string JoinURL { get; set; }
 
         /// <summary>
+        /// Gets or sets the tenant id.
+        /// Required when using short meeting URLs (e.g. https://teams.microsoft.com/meet/...).
+        /// The tenant id cannot be inferred from short URLs and must be provided separately.
+        /// </summary>
+        /// <value>The tenant id.</value>
+        public string TenantId { get; set; }
+
+        /// <summary>
         /// Gets or sets the display name.
         /// Teams client does not allow changing of ones own display name.
         /// If display name is specified, we join as anonymous (guest) user

--- a/Samples/PublicSamples/PsiBot/PsiBot/PsiBot.Service/Bot/BotService.cs
+++ b/Samples/PublicSamples/PsiBot/PsiBot/PsiBot.Service/Bot/BotService.cs
@@ -141,7 +141,9 @@ namespace PsiBot.Services.Bot
 
             var (chatInfo, meetingInfo) = ParseJoinURL(joinCallBody.JoinURL);
 
-            var tenantId = (meetingInfo as OrganizerMeetingInfo).Organizer.GetPrimaryIdentity().GetTenantId();
+            var tenantId =
+                joinCallBody.TenantId ??
+                (meetingInfo as OrganizerMeetingInfo)?.Organizer.GetPrimaryIdentity()?.GetTenantId();
             var mediaSession = this.CreateLocalMediaSession();
 
             var joinParams = new JoinMeetingParameters(chatInfo, meetingInfo, mediaSession)
@@ -338,43 +340,57 @@ namespace PsiBot.Services.Bot
 
             var decodedURL = WebUtility.UrlDecode(joinURL);
 
-            //// URL being needs to be in this format.
+            //// Long URL format:
             //// https://teams.microsoft.com/l/meetup-join/19:cd9ce3da56624fe69c9d7cd026f9126d@thread.skype/1509579179399?context={"Tid":"72f988bf-86f1-41af-91ab-2d7cd011db47","Oid":"550fae72-d251-43ec-868c-373732c2704f","MessageId":"1536978844957"}
 
             var regex = new Regex("https://teams\\.microsoft\\.com.*/(?<thread>[^/]+)/(?<message>[^/]+)\\?context=(?<context>{.*})");
             var match = regex.Match(decodedURL);
-            if (!match.Success)
+            if (match.Success)
             {
-                throw new ArgumentException($"Join URL cannot be parsed: {joinURL}", nameof(joinURL));
-            }
-
-            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(match.Groups["context"].Value)))
-            {
-                var ctxt = (Meeting)new DataContractJsonSerializer(typeof(Meeting)).ReadObject(stream);
-
-                if (string.IsNullOrEmpty(ctxt.Tid))
+                using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(match.Groups["context"].Value)))
                 {
-                    throw new ArgumentException("Join URL is invalid: missing Tid", nameof(joinURL));
-                }
+                    var ctxt = (Meeting)new DataContractJsonSerializer(typeof(Meeting)).ReadObject(stream);
 
-                var chatInfo = new ChatInfo
-                {
-                    ThreadId = match.Groups["thread"].Value,
-                    MessageId = match.Groups["message"].Value,
-                    ReplyChainMessageId = ctxt.MessageId,
-                };
-
-                var meetingInfo = new OrganizerMeetingInfo
-                {
-                    Organizer = new IdentitySet
+                    if (string.IsNullOrEmpty(ctxt.Tid))
                     {
-                        User = new Identity { Id = ctxt.Oid },
-                    },
-                };
-                meetingInfo.Organizer.User.SetTenantId(ctxt.Tid);
+                        throw new ArgumentException("Join URL is invalid: missing Tid", nameof(joinURL));
+                    }
 
-                return (chatInfo, meetingInfo);
+                    var chatInfo = new ChatInfo
+                    {
+                        ThreadId = match.Groups["thread"].Value,
+                        MessageId = match.Groups["message"].Value,
+                        ReplyChainMessageId = ctxt.MessageId,
+                    };
+
+                    var meetingInfo = new OrganizerMeetingInfo
+                    {
+                        Organizer = new IdentitySet
+                        {
+                            User = new Identity { Id = ctxt.Oid },
+                        },
+                    };
+                    meetingInfo.Organizer.User.SetTenantId(ctxt.Tid);
+
+                    return (chatInfo, meetingInfo);
+                }
             }
+
+            //// Short URL format: https://teams.microsoft.com/meet/<meetingId>?p=<passcode>
+            var shortUrlRegex = new Regex("https://teams\\.microsoft\\.com/meet/(?<meetingId>[^?]+)\\?p=(?<passcode>.+)");
+            var shortUrlMatch = shortUrlRegex.Match(decodedURL);
+            if (shortUrlMatch.Success)
+            {
+                var meetingInfo = new JoinMeetingIdMeetingInfo
+                {
+                    JoinMeetingId = shortUrlMatch.Groups["meetingId"].Value,
+                    Passcode = shortUrlMatch.Groups["passcode"].Value,
+                };
+
+                return (new ChatInfo(), meetingInfo);
+            }
+
+            throw new ArgumentException($"Join URL cannot be parsed: {joinURL}", nameof(joinURL));
         }
     }
 }

--- a/Samples/PublicSamples/PsiBot/PsiBot/PsiBot.Service/Bot/BotService.cs
+++ b/Samples/PublicSamples/PsiBot/PsiBot/PsiBot.Service/Bot/BotService.cs
@@ -144,6 +144,13 @@ namespace PsiBot.Services.Bot
             var tenantId =
                 joinCallBody.TenantId ??
                 (meetingInfo as OrganizerMeetingInfo)?.Organizer.GetPrimaryIdentity()?.GetTenantId();
+
+            if (string.IsNullOrWhiteSpace(tenantId))
+            {
+                throw new InvalidOperationException(
+                    "TenantId is required to join the meeting. " +
+                    "Ensure JoinCallBody.TenantId is provided or the meeting URL includes organizer tenant information.");
+            }
             var mediaSession = this.CreateLocalMediaSession();
 
             var joinParams = new JoinMeetingParameters(chatInfo, meetingInfo, mediaSession)

--- a/Samples/V1.0Samples/AksSamples(Deprecated)/teams-recording-bot/src/RecordingBot.Model/Models/JoinCallBody.cs
+++ b/Samples/V1.0Samples/AksSamples(Deprecated)/teams-recording-bot/src/RecordingBot.Model/Models/JoinCallBody.cs
@@ -25,6 +25,14 @@ namespace RecordingBot.Model.Models
         public string JoinURL { get; set; }
 
         /// <summary>
+        /// Gets or sets the tenant id.
+        /// Required when using short meeting URLs (e.g. https://teams.microsoft.com/meet/...).
+        /// The tenant id cannot be inferred from short URLs and must be provided separately.
+        /// </summary>
+        /// <value>The tenant id.</value>
+        public string TenantId { get; set; }
+
+        /// <summary>
         /// Gets or sets the display name.
         /// Teams client does not allow changing of ones own display name.
         /// If display name is specified, we join as anonymous (guest) user

--- a/Samples/V1.0Samples/AksSamples(Deprecated)/teams-recording-bot/src/RecordingBot.Services/Bot/BotService.cs
+++ b/Samples/V1.0Samples/AksSamples(Deprecated)/teams-recording-bot/src/RecordingBot.Services/Bot/BotService.cs
@@ -151,7 +151,9 @@ namespace RecordingBot.Services.Bot
 
             var (chatInfo, meetingInfo) = JoinInfo.ParseJoinURL(joinCallBody.JoinURL);
 
-            var tenantId = (meetingInfo as OrganizerMeetingInfo).Organizer.GetPrimaryIdentity().GetTenantId();
+            var tenantId =
+                joinCallBody.TenantId ??
+                (meetingInfo as OrganizerMeetingInfo)?.Organizer.GetPrimaryIdentity()?.GetTenantId();
             var mediaSession = this.CreateLocalMediaSession();
 
             var joinParams = new JoinMeetingParameters(chatInfo, meetingInfo, mediaSession)

--- a/Samples/V1.0Samples/AksSamples(Deprecated)/teams-recording-bot/src/RecordingBot.Services/Bot/BotService.cs
+++ b/Samples/V1.0Samples/AksSamples(Deprecated)/teams-recording-bot/src/RecordingBot.Services/Bot/BotService.cs
@@ -154,6 +154,13 @@ namespace RecordingBot.Services.Bot
             var tenantId =
                 joinCallBody.TenantId ??
                 (meetingInfo as OrganizerMeetingInfo)?.Organizer.GetPrimaryIdentity()?.GetTenantId();
+
+            if (string.IsNullOrWhiteSpace(tenantId))
+            {
+                throw new InvalidOperationException(
+                    "TenantId is required to join the call. " +
+                    "Ensure that JoinCallBody.TenantId is set or the meeting URL contains organizer tenant information.");
+            }
             var mediaSession = this.CreateLocalMediaSession();
 
             var joinParams = new JoinMeetingParameters(chatInfo, meetingInfo, mediaSession)

--- a/Samples/V1.0Samples/AksSamples(Deprecated)/teams-recording-bot/src/RecordingBot.Services/Util/JoinInfo.cs
+++ b/Samples/V1.0Samples/AksSamples(Deprecated)/teams-recording-bot/src/RecordingBot.Services/Util/JoinInfo.cs
@@ -44,43 +44,57 @@ namespace RecordingBot.Services.Util
 
             var decodedURL = WebUtility.UrlDecode(joinURL);
 
-            //// URL being needs to be in this format.
+            //// Long URL format:
             //// https://teams.microsoft.com/l/meetup-join/19:cd9ce3da56624fe69c9d7cd026f9126d@thread.skype/1509579179399?context={"Tid":"72f988bf-86f1-41af-91ab-2d7cd011db47","Oid":"550fae72-d251-43ec-868c-373732c2704f","MessageId":"1536978844957"}
 
             var regex = new Regex("https://teams\\.microsoft\\.com.*/(?<thread>[^/]+)/(?<message>[^/]+)\\?context=(?<context>{.*})");
             var match = regex.Match(decodedURL);
-            if (!match.Success)
+            if (match.Success)
             {
-                throw new ArgumentException($"Join URL cannot be parsed: {joinURL}", nameof(joinURL));
-            }
-
-            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(match.Groups["context"].Value)))
-            {
-                var ctxt = (Meeting)new DataContractJsonSerializer(typeof(Meeting)).ReadObject(stream);
-
-                if (string.IsNullOrEmpty(ctxt.Tid))
+                using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(match.Groups["context"].Value)))
                 {
-                    throw new ArgumentException("Join URL is invalid: missing Tid", nameof(joinURL));
-                }
+                    var ctxt = (Meeting)new DataContractJsonSerializer(typeof(Meeting)).ReadObject(stream);
 
-                var chatInfo = new ChatInfo
-                {
-                    ThreadId = match.Groups["thread"].Value,
-                    MessageId = match.Groups["message"].Value,
-                    ReplyChainMessageId = ctxt.MessageId,
-                };
-
-                var meetingInfo = new OrganizerMeetingInfo
-                {
-                    Organizer = new IdentitySet
+                    if (string.IsNullOrEmpty(ctxt.Tid))
                     {
-                        User = new Identity { Id = ctxt.Oid },
-                    },
-                };
-                meetingInfo.Organizer.User.SetTenantId(ctxt.Tid);
+                        throw new ArgumentException("Join URL is invalid: missing Tid", nameof(joinURL));
+                    }
 
-                return (chatInfo, meetingInfo);
+                    var chatInfo = new ChatInfo
+                    {
+                        ThreadId = match.Groups["thread"].Value,
+                        MessageId = match.Groups["message"].Value,
+                        ReplyChainMessageId = ctxt.MessageId,
+                    };
+
+                    var meetingInfo = new OrganizerMeetingInfo
+                    {
+                        Organizer = new IdentitySet
+                        {
+                            User = new Identity { Id = ctxt.Oid },
+                        },
+                    };
+                    meetingInfo.Organizer.User.SetTenantId(ctxt.Tid);
+
+                    return (chatInfo, meetingInfo);
+                }
             }
+
+            //// Short URL format: https://teams.microsoft.com/meet/<meetingId>?p=<passcode>
+            var shortUrlRegex = new Regex("https://teams\\.microsoft\\.com/meet/(?<meetingId>[^?]+)\\?p=(?<passcode>.+)");
+            var shortUrlMatch = shortUrlRegex.Match(decodedURL);
+            if (shortUrlMatch.Success)
+            {
+                var meetingInfo = new JoinMeetingIdMeetingInfo
+                {
+                    JoinMeetingId = shortUrlMatch.Groups["meetingId"].Value,
+                    Passcode = shortUrlMatch.Groups["passcode"].Value,
+                };
+
+                return (new ChatInfo(), meetingInfo);
+            }
+
+            throw new ArgumentException($"Join URL cannot be parsed: {joinURL}", nameof(joinURL));
         }
     }
 }


### PR DESCRIPTION
Teams now generates short meeting URLs in the format: https://teams.microsoft.com/meet/<meetingId>?p=<passcode>

The existing ParseJoinURL only supports the legacy long format with context parameters. This change adds a fallback to parse short URLs using JoinMeetingIdMeetingInfo instead of OrganizerMeetingInfo.

For short URLs, the tenant ID cannot be inferred from the URL and must be provided separately via the JoinCallBody.TenantId property (added to models that lacked it).

Changes:
- Updated ParseJoinURL in all 6 JoinInfo implementations to detect and parse both long and short URL formats
- Added TenantId property to JoinCallBody in EchoBot, PsiBot, and RecordingBot models
- Updated callers to safely handle both OrganizerMeetingInfo and JoinMeetingIdMeetingInfo return types using null-safe tenant extraction with JoinCallBody.TenantId fallback

Fixes microsoftgraph/microsoft-graph-comms-samples#829