### PR TITLE
Fix for System.InvalidOperationException

### DIFF
--- a/Samples/PublicSamples/PsiBot/PsiBot/PsiBot.Service/appsettings.json
+++ b/Samples/PublicSamples/PsiBot/PsiBot/PsiBot.Service/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Info"
+      "Default": "Information"
     }
   },
   "AllowedHosts": "*",


### PR DESCRIPTION
Fix for the System.InvalidOperationException: Configuration value 'Info' is not supported.

Info is not supported updating it with Information